### PR TITLE
Fix wrong apksigner extension problem

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -113,7 +113,7 @@ function getJavaHome () {
  * @throws {Error} If the tool is not present on the local file system.
  */
 async function getApksignerForOs (sysHelpers) {
-  return await sysHelpers.getBinaryFromSdkRoot(`apksigner${system.isWindows() ? '.bat' : ''}`);
+  return await sysHelpers.getBinaryFromSdkRoot('apksigner');
 }
 
  /**

--- a/lib/tools/system-calls.js
+++ b/lib/tools/system-calls.js
@@ -50,7 +50,7 @@ systemCallMethods.getCommandForOS = function () {
  */
 systemCallMethods.getBinaryNameForOS = function (binaryName) {
   if (system.isWindows()) {
-    if (binaryName === "android") {
+    if (binaryName === "android" || binaryName == "apksigner") {
       binaryName += ".bat";
     } else {
       if (binaryName.indexOf(".exe", binaryName.length - 4) === -1) {


### PR DESCRIPTION
https://github.com/appium/appium-adb/pull/277 related commit.
I found still apksigner.bat.exe  is called on Windows due to `systemCallMethods.getBinaryNameForOS` logic, and I confirmed this fix called apksigner.bat correctly on my Windows PC.